### PR TITLE
Remove obvious "pure virtual" marker in compiled cpp file, add empty …

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,49 @@ val key = Secrets().getYourSecretKeyName(packageName)
 String key = new Secrets().getYourSecretKeyName(getPackageName());
 ```
 
+# 4 - (Optional) Improve your key security
+You can improve the security of your key by encoding it before to call `gradle hideSecretKey`.
+
+For this example we will use a [rot13 algorithm](https://en.wikipedia.org/wiki/ROT13) to encode/decode our key.
+
+You need to encode your key first, for rot13 you can find many online services to do it.
+Then your key `yourKeyToObfuscate` becomes `lbheXrlGbBoshfpngr` after a rot13.
+Add it in your app :
+```shell
+gradle hideSecretKey -Pkey=lbheXrlGbBoshfpngr -PkeyName=YourSecretKeyName -Ppackage=com.your.package
+```
+
+Then in `secrets.cpp` you need to add your own decoding code in `customDecode` method:
+```cpp
+void customDecode(char *str) {
+    //Add your own logic here
+    //To improve your key security you can encode it before to integrate it in the app.
+    //And then decode it with your own logic in this function.
+    int c = 13;
+    int l = strlen(str);
+    const char *alpha[2] = { "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ"};
+
+    int i;
+    for (i = 0; i < l; i++)
+    {
+        if (!isalpha(str[i]))
+            continue;
+
+        if (isupper(str[i]))
+            str[i] = alpha[1][((int)(tolower(str[i]) - 'a') + c) % 26];
+        else
+            str[i] = alpha[0][((int)(tolower(str[i]) - 'a') + c) % 26];
+    }
+}
+```
+
+This method is automatically called and will revert the rot13 applied on your key when you will call :
+```kotlin
+Secrets().getYourSecretKeyName(packageName)
+```
+
+⚠️ It is strongly recommended to not use this rot13 algorithm and to use another custom solution to encode/decode your key.
+
 ## Other available commands
 Unzip `.jar` file in `/build/` temporary directory :
 ```shell

--- a/src/main/kotlin/com/klaxit/hiddensecrets/CodeGenerator.kt
+++ b/src/main/kotlin/com/klaxit/hiddensecrets/CodeGenerator.kt
@@ -26,7 +26,7 @@ class CodeGenerator {
          */
         fun getKotlinCode(keyName: String): String {
             return "\n    external fun get$keyName(packageName: String): String\n" +
-                    "}\n"
+                    "}"
         }
     }
 }

--- a/src/main/resources/cpp/secrets.cpp
+++ b/src/main/resources/cpp/secrets.cpp
@@ -30,24 +30,33 @@
 * OTHER DEALINGS IN THE SOFTWARE.
 */
 
+void customDecode(char *str) {
+    //Add your own logic here
+    //To improve your key security you can encode it before to integrate it in the app.
+    //And then decode it with your own logic in this function.
+}
+
 jstring getOriginalKey(
-        char* obfuscatedSecret,
+        char *obfuscatedSecret,
         int obfuscatedSecretSize,
         jstring obfuscatingJStr,
-        JNIEnv* pEnv) {
+        JNIEnv *pEnv) {
 
     // Get the obfuscating string SHA256 as the obfuscator
-    std::string obfuscatingStr = std::string(pEnv->GetStringUTFChars(obfuscatingJStr, NULL));
-    std::string obfuscator = sha256(obfuscatingStr);
+    const char *obfuscatingStr = pEnv->GetStringUTFChars(obfuscatingJStr, NULL);
+    const char *obfuscator = sha256(obfuscatingStr);
 
     // Apply a XOR between the obfuscated key and the obfuscating string to get original sting
     char out[obfuscatedSecretSize + 1];
-    for(int i=0; i < obfuscatedSecretSize; i++){
-        out[i] = obfuscatedSecret[i] ^ obfuscator[i % obfuscator.length()];
+    for (int i = 0; i < obfuscatedSecretSize; i++) {
+        out[i] = obfuscatedSecret[i] ^ obfuscator[i % strlen(obfuscator)];
     }
 
     // Add string terminal delimiter
     out[obfuscatedSecretSize] = 0x0;
+
+    //(Optional) To improve key security
+    customDecode(out);
 
     return pEnv->NewStringUTF(out);
 }
@@ -55,9 +64,9 @@ jstring getOriginalKey(
 extern "C"
 JNIEXPORT jstring JNICALL
 Java_YOUR_PACKAGE_GOES_HERE_Secrets_getYOUR_KEY_NAME_GOES_HERE(
-        JNIEnv* pEnv,
+        JNIEnv *pEnv,
         jobject pThis,
         jstring packageName) {
-     char obfuscatedSecret[] = {YOUR_KEY_GOES_HERE};
-     return getOriginalKey(obfuscatedSecret, sizeof(obfuscatedSecret), packageName, pEnv);
+    char obfuscatedSecret[] = {YOUR_KEY_GOES_HERE};
+    return getOriginalKey(obfuscatedSecret, sizeof(obfuscatedSecret), packageName, pEnv);
 }

--- a/src/main/resources/cpp/sha256.cpp
+++ b/src/main/resources/cpp/sha256.cpp
@@ -151,20 +151,20 @@ void SHA256::final(unsigned char *digest)
     }
 }
  
-std::string sha256(std::string input)
+const char* sha256(const char* input)
 {
     unsigned char digest[SHA256::DIGEST_SIZE];
     memset(digest,0,SHA256::DIGEST_SIZE);
  
     SHA256 ctx = SHA256();
     ctx.init();
-    ctx.update( (unsigned char*)input.c_str(), input.length());
+    ctx.update( (unsigned char*)input, strlen(input));
     ctx.final(digest);
  
     char buf[2*SHA256::DIGEST_SIZE+1];
     buf[2*SHA256::DIGEST_SIZE] = 0;
     for (int i = 0; i < SHA256::DIGEST_SIZE; i++)
         sprintf(buf+i*2, "%02x", digest[i]);
-    return std::string(buf);
+    return buf;
 }
 

--- a/src/main/resources/cpp/sha256.hpp
+++ b/src/main/resources/cpp/sha256.hpp
@@ -25,7 +25,7 @@ protected:
     uint32 m_h[8];
 };
 
-std::string sha256(std::string input);
+const char* sha256(const char* input);
 
 #define SHA2_SHFR(x, n)    (x >> n)
 #define SHA2_ROTR(x, n)   ((x >> n) | (x << ((sizeof(x) << 3) - n)))


### PR DESCRIPTION
- Suppression des markers évidents après compilation, le fichier compilé passe de 200ko à 10ko
- Ajout d'une fonction de décodage vide et prête à recevoir du code
- Ajout de la doc correspondante avec l'exemple complet du rot13
- Correction de la génération de code Kotlin lors de l'ajout d'une clé

J'ai ne pas trouvé le moyen d'intégrer dans le plugin une fonction custom d'encodage/décodage réversible en cpp exécutée par le plugin et qui serait copiée dans le projet du user pour le décodage.

Par conséquent j'ai choisi la solution de ne pas intégrer la fonction de décodage par défaut mais d'expliquer comment faire dans la doc. Au final ça laisse encore plus de liberté sur l'encodage/decodage custom aux users motivés.