### PR TITLE
Add possibility of an optional encryption method

### DIFF
--- a/src/main/resources/cpp/secrets.cpp
+++ b/src/main/resources/cpp/secrets.cpp
@@ -30,6 +30,13 @@
 * OTHER DEALINGS IN THE SOFTWARE.
 */
 
+void customDecode(char *str) {
+    /* Add your own logic here
+    * To improve your key security you can encode it before to integrate it in the app.
+    * And then decode it with your own logic in this function.
+    */
+}
+
 jstring getOriginalKey(
         char* obfuscatedSecret,
         int obfuscatedSecretSize,
@@ -48,6 +55,9 @@ jstring getOriginalKey(
 
     // Add string terminal delimiter
     out[obfuscatedSecretSize] = 0x0;
+
+    //(Optional) To improve key security
+    customDecode(out);
 
     return pEnv->NewStringUTF(out);
 }


### PR DESCRIPTION
Ajout d'une sécurité supplémentaire.

L'utilisateur peut facilement ajouter au code sa propre méthode de décodage de clé pour renforcer la sécurité.

Un exemple avec rot13 est fait dans la documentation.