### PR TITLE
Easier way to use hidden secrets in your project

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,12 @@ Then sync your Android project.
 
 # 2 - Hide secret key in your project
 
-Prepare your project by adding required files :
-```shell
-gradle setupHiddenSecrets -Ppackage=com.your.package
-```
-
 Obfuscate and hide your key in your project :
 ```shell
-gradle hideSecretKey -Pkey=yourKeyToObfuscate -PkeyName=YourSecretKeyName -Ppackage=com.your.package
+gradle hideSecret -Pkey=yourKeyToObfuscate [-PkeyName=YourSecretKeyName] [-Ppackage=com.your.package]
 ```
+The parameter `keyName` is optional, by default the key name is randomly generated.
+The parameter `package` is optional, by default the `applicationId` of your project will be used.
 
 # 3 - Get your secret key in your app
 👏 You can now get your secret key from Java/Kotlin code by calling :
@@ -94,7 +91,7 @@ As an example, we will use a [rot13 algorithm](https://en.wikipedia.org/wiki/ROT
 After a rot13 encoding your key `yourKeyToObfuscate` becomes `lbheXrlGbBoshfpngr`.
 Add it in your app :
 ```shell
-gradle hideSecretKey -Pkey=lbheXrlGbBoshfpngr -PkeyName=YourSecretKeyName -Ppackage=com.your.package
+gradle hideSecret -Pkey=lbheXrlGbBoshfpngr -PkeyName=YourSecretKeyName
 ```
 
 Then in `secrets.cpp` you need to add your own decoding code in `customDecode` method:
@@ -130,12 +127,12 @@ gradle unzipHiddenSecrets
 Copy required files to your project :
 ```shell
 gradle copyCpp
-gradle copyKotlin -Ppackage=your.package.name
+gradle copyKotlin [-Ppackage=your.package.name]
 ```
 
 Create an obfuscated key and display it :
 ```shell
-gradle obfuscateKey -Pkey=yourKeyToObfuscate -Ppackage=com.your.package
+gradle obfuscate -Pkey=yourKeyToObfuscate [-Ppackage=com.your.package]
 ```
 
 ## Development

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,15 @@ version = "1.0.0"
 
 repositories {
     mavenCentral()
+    google()
+    jcenter()
 }
 
 dependencies {
-    implementation("org.codehaus.groovy:groovy-all:2.5.8")
-    //testImplementation("junit", "junit", "4.12")
+    implementation("com.android.tools.build:gradle:4.0.0")
+
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.1.10")
+    testImplementation("junit:junit:4.13")
 }
 
 configure<JavaPluginConvention> {

--- a/src/main/kotlin/com/klaxit/hiddensecrets/Utils.kt
+++ b/src/main/kotlin/com/klaxit/hiddensecrets/Utils.kt
@@ -64,6 +64,5 @@ class Utils {
 
             return encoded
         }
-
     }
 }

--- a/src/test/kotlin/HiddenSecretsTest.kt
+++ b/src/test/kotlin/HiddenSecretsTest.kt
@@ -2,8 +2,10 @@ import com.klaxit.hiddensecrets.HiddenSecretsPlugin
 import io.kotlintest.shouldNotBe
 import io.kotlintest.specs.WordSpec
 import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.rules.TemporaryFolder
 
-class HiddenSecretsTest : WordSpec ({
+class HiddenSecretsTest : WordSpec({
 
     "Using the Plugin ID" should {
         "Apply the Plugin" {
@@ -11,7 +13,31 @@ class HiddenSecretsTest : WordSpec ({
             project.pluginManager.apply("com.klaxit.HiddenSecrets")
 
             val plugin = project.plugins.getPlugin(HiddenSecretsPlugin::class.java)
-            plugin shouldNotBe  null
+            plugin shouldNotBe null
+        }
+    }
+
+    "Apply the plugin" should {
+        val testProjectDir = TemporaryFolder()
+        testProjectDir.create()
+        val buildFile = testProjectDir.newFile("build.gradle")
+        buildFile.appendText("""
+        plugins {
+            id 'com.klaxit.hiddensecrets'
+        }
+        """.trimIndent())
+        val gradleRunner = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir.root)
+                .withTestKitDir(testProjectDir.newFolder())
+
+        "Make command copyCpp works" {
+            val result = gradleRunner.withArguments("copyCpp").build()
+            println(result.output)
+        }
+        "Make command copyKotlin works" {
+            val result = gradleRunner.withArguments("copyCpp").build()
+            println(result.output)
         }
     }
 })

--- a/src/test/kotlin/UtilsTest.kt
+++ b/src/test/kotlin/UtilsTest.kt
@@ -1,0 +1,21 @@
+import com.klaxit.hiddensecrets.Utils
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.WordSpec
+
+class UtilsTest : WordSpec({
+
+    "Using getUnderScoredPackageName()" should {
+        "transform package separator" {
+            val sourcePackage = "com.klaxit.test"
+            Utils.getUnderScoredPackageName(sourcePackage) shouldBe "com_klaxit_test"
+        }
+    }
+
+    "Using encodeSecret()" should {
+        "encode String with a seed" {
+            val key = "keyToEncode"
+            val packageName = "com.klaxit.test"
+            Utils.encodeSecret(key,packageName) shouldBe "{ 0x5b, 0x6, 0x18, 0x31, 0xb, 0x72, 0x57, 0x5, 0x5d, 0x57, 0x3 }"
+        }
+    }
+})


### PR DESCRIPTION
Hello,

I made some improvements to make the plugin more easy to use :
- Easier commands to add secret keys: shorter names, optional arguments instead of required, and remove the setup command.
- Automatically resolve project package.
- Clearer errors if an argument is missing.
- Avoid to overwrite already included Kotlin or C++ files.
- 1 functional and 2 unit tests added.