### PR TITLE
Update the test sdk from old kotlintest to kotest and add some tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ To get started, checkout the code and run `./gradlew build` to create the `.jar`
 
 Before opening a PR :
 - make sure that you have tested your code carefully
-- `/gradlew test` must succeed
-- `/gradlew detekt` must succeed to avoid any style issue
+- `./gradlew test` must succeed
+- `./gradlew detekt` must succeed to avoid any style issue
 
 ## Authors
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,9 +16,10 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:4.0.0")
+    implementation("com.android.tools.build:gradle:4.0.2")
 
-    testImplementation("io.kotlintest:kotlintest-runner-junit5:3.1.11")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.3.1")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:4.3.1")
     testImplementation("junit:junit:4.13.1")
 }
 

--- a/src/main/kotlin/com/klaxit/hiddensecrets/HiddenSecretsPlugin.kt
+++ b/src/main/kotlin/com/klaxit/hiddensecrets/HiddenSecretsPlugin.kt
@@ -21,12 +21,12 @@ open class HiddenSecretsPlugin : Plugin<Project> {
         private const val DEFAULT_KEY_NAME_LENGTH = 8
 
         //Tasks
-        private const val TASK_UNZIP_HIDDEN_SECRETS = "unzipHiddenSecrets"
-        private const val TASK_COPY_CPP = "copyCpp"
-        private const val TASK_COPY_KOTLIN = "copyKotlin"
-        private const val TASK_OBFUSCATE = "obfuscate"
-        private const val TASK_HIDE_SECRET = "hideSecret"
-        private const val TASK_PACKAGE_NAME = "packageName"
+        const val TASK_UNZIP_HIDDEN_SECRETS = "unzipHiddenSecrets"
+        const val TASK_COPY_CPP = "copyCpp"
+        const val TASK_COPY_KOTLIN = "copyKotlin"
+        const val TASK_HIDE_SECRET = "hideSecret"
+        const val TASK_OBFUSCATE = "obfuscate"
+        const val TASK_PACKAGE_NAME = "packageName"
 
         //Properties
         private const val KEY = "key"

--- a/src/test/kotlin/CommandNamesTest.kt
+++ b/src/test/kotlin/CommandNamesTest.kt
@@ -1,0 +1,15 @@
+import com.klaxit.hiddensecrets.HiddenSecretsPlugin
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Test that command names did not change.
+ */
+class CommandNamesTest : StringSpec({
+    HiddenSecretsPlugin.TASK_UNZIP_HIDDEN_SECRETS shouldBe  "unzipHiddenSecrets"
+    HiddenSecretsPlugin.TASK_COPY_CPP shouldBe "copyCpp"
+    HiddenSecretsPlugin.TASK_COPY_KOTLIN shouldBe "copyKotlin"
+    HiddenSecretsPlugin.TASK_HIDE_SECRET shouldBe "hideSecret"
+    HiddenSecretsPlugin.TASK_OBFUSCATE shouldBe "obfuscate"
+    HiddenSecretsPlugin.TASK_PACKAGE_NAME shouldBe "packageName"
+})

--- a/src/test/kotlin/HiddenSecretsTest.kt
+++ b/src/test/kotlin/HiddenSecretsTest.kt
@@ -1,7 +1,12 @@
-import io.kotlintest.specs.WordSpec
+import com.klaxit.hiddensecrets.HiddenSecretsPlugin
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.string.shouldContain
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.rules.TemporaryFolder
 
+/**
+ * Test that HiddenSecrets commands are working.
+ */
 class HiddenSecretsTest : WordSpec({
 
     "Apply the plugin" should {
@@ -11,16 +16,41 @@ class HiddenSecretsTest : WordSpec({
         buildFile.appendText("""
         plugins {
             id 'com.klaxit.hiddensecrets'
+            id 'com.android.application'
+        }
+        android {
+            compileSdkVersion 29
         }
         """.trimIndent())
         val gradleRunner = GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(testProjectDir.root)
-                .withTestKitDir(testProjectDir.newFolder())
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir.root)
+            .withTestKitDir(testProjectDir.newFolder())
 
-        "Make command copyCpp works" {
-            val result = gradleRunner.withArguments("copyCpp").build()
+        //Properties
+        val key = "thisIsATestKey"
+        val packageName = "com.package.test"
+
+        "Make command ${HiddenSecretsPlugin.TASK_COPY_CPP} succeed" {
+            val result = gradleRunner.withArguments(HiddenSecretsPlugin.TASK_COPY_CPP).build()
             println(result.output)
+        }
+
+        "Make command ${HiddenSecretsPlugin.TASK_COPY_KOTLIN} succeed" {
+            val result = gradleRunner.withArguments(HiddenSecretsPlugin.TASK_COPY_KOTLIN, "-Ppackage=$packageName").build()
+            println(result.output)
+        }
+
+        "Make command ${HiddenSecretsPlugin.TASK_OBFUSCATE} succeed" {
+            val result = gradleRunner.withArguments(HiddenSecretsPlugin.TASK_OBFUSCATE, "-Pkey=$key", "-Ppackage=$packageName").build()
+            println(result.output)
+            result.output shouldContain "{ 0x15, 0x58, 0xb, 0x43, 0x78, 0x4a, 0x23, 0x6d, 0x1, 0x4b, 0x46, 0x7c, 0x57, 0x41 }" //obfuscated key
+        }
+
+        "Make command ${HiddenSecretsPlugin.TASK_PACKAGE_NAME} succeed" {
+            val result = gradleRunner.withArguments(HiddenSecretsPlugin.TASK_PACKAGE_NAME, "-Ppackage=$packageName").build()
+            println(result.output)
+            result.output shouldContain packageName
         }
     }
 })

--- a/src/test/kotlin/UtilsTest.kt
+++ b/src/test/kotlin/UtilsTest.kt
@@ -1,13 +1,17 @@
 import com.klaxit.hiddensecrets.Utils
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.WordSpec
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
 
+/**
+ * Test Utils methods.
+ */
 class UtilsTest : WordSpec({
+
+    val packageName = "com.klaxit.test"
 
     "Using getUnderScoredPackageName()" should {
         "transform package separator" {
-            val sourcePackage = "com.klaxit.test"
-            Utils.getUnderScoredPackageName(sourcePackage) shouldBe "com_klaxit_test"
+            Utils.getUnderScoredPackageName(packageName) shouldBe "com_klaxit_test"
         }
     }
 
@@ -21,12 +25,10 @@ class UtilsTest : WordSpec({
     "Using encodeSecret()" should {
         "encode String with a seed" {
             val key = "keyToEncode"
-            val packageName = "com.klaxit.test"
             Utils.encodeSecret(key, packageName) shouldBe "{ 0x5b, 0x6, 0x18, 0x31, 0xb, 0x72, 0x57, 0x5, 0x5d, 0x57, 0x3 }"
         }
         "encode String with special characters" {
             val key = "@&é(§èçà)-ù,;:=#°_*%£?./+"
-            val packageName = "com.klaxit.test"
             Utils.encodeSecret(key, packageName) shouldBe "{ 0x70, 0x45, 0xa2, 0xcc, 0x4c, 0xf5, 0x9e, 0xa5, 0x9a, 0xf0, 0xc1, 0xa6, 0x92, 0x4a, 0x4e, 0xa6, 0x8a, 0x1a, 0xc, 0x5e, 0x5, 0x14, 0xf7, 0x86, 0x6b, 0x13, 0x40, 0xf5, 0x9a, 0xc, 0x16, 0x16, 0x19 }"
         }
     }


### PR DESCRIPTION
The goal of this PR is to improve current test config to prepare to add more tests.
- update from old kotlintest to the latest version of kotest
- make task names public
- add commands test
- add commands names test
- fix typo in readme