### PR TITLE
Generate secrets from .properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 .gradle/
 build/
 .idea/
+
+# Local files
+.java-version
+local.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * Fix build on Mac with M1 chip
 ### Improvements
 * Update Gradle, Detekt, and Kotest
+# v0.2.0
+### Improvements
+* Ability to re-generate secrets from .properties file
+* Group Gradle tasks and their descriptions to convenience command `tasks`
 # v0.1.2
 ### Fixes
 * Fix call to `customDecode()` in C++ code

--- a/README.md
+++ b/README.md
@@ -119,23 +119,54 @@ This method is automatically called and will revert the rot13 applied on your ke
 Secrets().getYourSecretKeyName(packageName)
 ```
 
-## Other available commands
+# Going further
+## Generate secrets from properties file
+You can generate secrets from properties file as well. 
 
-### Copy files
+### Use case
+If you are using CI system to provide secrets, that are not hard-coded into the repository itself. It will re-generate those secrets in the app and build it. 
+
+This is useful if you want to split production keys from repository itself, thus increasing security in your project repository. 
+
+### Setting up
+1. Create a new properties file in root project directory. 
+
+``` shell
+credentials.properties
+```
+
+2. Fill in wanted secrets. For ex.: 
+
+``` java-properties
+secret1=yourKeyToObfuscate1
+secret2=yourKeyToObfuscate2
+```
+
+3. Run
+
+``` shell
+./gradlew hideSecretFromPropertiesFile -PpropertiesFileName=credentials.properties
+```
+
+It will regenerate all secret files in the project and update all secrets from the properties file.
+
+# Other available commands
+
+## Copy files
 Copy required files to your project :
 ```shell
 ./gradlew copyCpp
 ./gradlew copyKotlin [-Ppackage=your.package.name]
 ```
 
-### Obfuscate
+## Obfuscate
 Create an obfuscated key and display it :
 ```shell
 ./gradlew obfuscate -Pkey=yourKeyToObfuscate [-Ppackage=com.your.package]
 ```
 This command can be useful if you modify your app's package name based on `buildTypes` configuration. With this command you can get the obfuscated key for a different package name and manually integrate it in another function in `secrets.cpp`.
 
-## Development
+# Development
 
 Pull Requests are very welcome!
 
@@ -146,10 +177,11 @@ Before opening a PR :
 - `./gradlew test` must succeed
 - `./gradlew detekt` must succeed to avoid any style issue
 
-## Authors
+# Authors
 
 See the list of [contributors](https://github.com/klaxit/hidden-secrets-gradle-plugin/contributors) who participated in this project.
 
-## License
+# License
 
 Please see [LICENSE](https://github.com/klaxit/hidden-secrets-gradle-plugin/blob/master/LICENSE)
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,5 +2,5 @@ rootProject.name = "HiddenSecretsPlugin"
 
 gradle.allprojects {
   group = "com.klaxit.hiddensecrets"
-  version = "0.1.3"
+  version = "0.2.0"
 }

--- a/src/main/kotlin/com/klaxit/hiddensecrets/HiddenSecretsPlugin.kt
+++ b/src/main/kotlin/com/klaxit/hiddensecrets/HiddenSecretsPlugin.kt
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.charset.Charset
+import java.util.Properties
 
 /**
  * Available gradle tasks from HiddenSecretsPlugin
@@ -24,22 +25,28 @@ open class HiddenSecretsPlugin : Plugin<Project> {
         private const val KOTLIN_FILE_NAME = "Secrets.kt"
 
         //Tasks
+        const val TASK_GROUP = "Hide secrets"
         const val TASK_UNZIP_HIDDEN_SECRETS = "unzipHiddenSecrets"
         const val TASK_COPY_CPP = "copyCpp"
         const val TASK_COPY_KOTLIN = "copyKotlin"
         const val TASK_HIDE_SECRET = "hideSecret"
+        const val TASK_HIDE_SECRET_FROM_PROPS = "hideSecretFromPropertiesFile"
         const val TASK_OBFUSCATE = "obfuscate"
         const val TASK_PACKAGE_NAME = "packageName"
         const val TASK_FIND_KOTLIN_FILE = "findKotlinFile"
 
         //Properties
-        private const val KEY = "key"
-        private const val KEY_NAME = "keyName"
-        private const val PACKAGE = "package"
+        private const val PROP_KEY = "key"
+        private const val PROP_KEY_NAME = "keyName"
+        private const val PROP_PACKAGE = "package"
+        private const val PROP_FROM_PROPS = "propertiesFileName"
 
         //Errors
         private const val ERROR_EMPTY_KEY = "No key provided, use argument '-Pkey=yourKey'"
         private const val ERROR_EMPTY_PACKAGE = "Empty package name, use argument '-Ppackage=your.package.name'"
+
+        // Sample usage
+        private const val SAMPLE_FROM_PROPS = "-P${PROP_FROM_PROPS}=creds.properties"
     }
 
     override fun apply(project: Project) {
@@ -64,9 +71,9 @@ open class HiddenSecretsPlugin : Plugin<Project> {
         @Input
         fun getKeyParam(): String {
             val key: String
-            if (project.hasProperty(KEY)) {
+            if (project.hasProperty(PROP_KEY)) {
                 //From command line
-                key = project.property(KEY) as String
+                key = project.property(PROP_KEY) as String
             } else {
                 throw InvalidUserDataException(ERROR_EMPTY_KEY)
             }
@@ -79,9 +86,9 @@ open class HiddenSecretsPlugin : Plugin<Project> {
         @Input
         fun getPackageNameParam(): String {
             var packageName: String? = null
-            if (project.hasProperty(PACKAGE)) {
+            if (project.hasProperty(PROP_PACKAGE)) {
                 //From command line
-                packageName = project.property(PACKAGE) as String?
+                packageName = project.property(PROP_PACKAGE) as String?
             }
             if (packageName.isNullOrEmpty()) {
                 //From Android app
@@ -94,6 +101,42 @@ open class HiddenSecretsPlugin : Plugin<Project> {
         }
 
         /**
+         * Get properties file path to hide secrets from
+         */
+        @Input
+        fun getPropertiesFile(): File {
+            return if (project.hasProperty(PROP_FROM_PROPS)) {
+                val propsPathRaw = project.property(PROP_FROM_PROPS)
+                if (propsPathRaw != null) {
+                    File(project.rootDir, propsPathRaw as String)
+                } else {
+                    throw IllegalArgumentException("Cannot find properties (${propsPathRaw})!" +
+                        " Use: '${SAMPLE_FROM_PROPS}'")
+                }
+            } else {
+                throw IllegalArgumentException("Properties file is not defined!" +
+                    " Use: '${SAMPLE_FROM_PROPS}'")
+            }
+        }
+
+        /**
+         * Get properties file to hide secrets from
+         * @throws IllegalArgumentException no props found in project
+         */
+        @Throws(IllegalArgumentException::class)
+        fun getPropertiesFromFile(propertiesFile: File): Properties {
+            if (!propertiesFile.exists()) {
+                throw IllegalArgumentException("Cannot find properties (${propertiesFile.absolutePath})!" +
+                    " Use: '${SAMPLE_FROM_PROPS}'")
+            }
+            return Properties().apply {
+                propertiesFile.inputStream().use {
+                    load(it)
+                }
+            }
+        }
+
+        /**
          * Get key name param from command line
          */
         @Input
@@ -101,9 +144,9 @@ open class HiddenSecretsPlugin : Plugin<Project> {
             val chars = ('a'..'z') + ('A'..'Z')
             // Default random key name
             var keyName = List(DEFAULT_KEY_NAME_LENGTH) { chars.random() }.joinToString("")
-            if (project.hasProperty(KEY_NAME)) {
+            if (project.hasProperty(PROP_KEY_NAME)) {
                 //From command line
-                keyName = project.property(KEY_NAME) as String
+                keyName = project.property(PROP_KEY_NAME) as String
             } else {
                 println("Key name has been randomized, chose your own key name by adding argument '-PkeyName=yourName'")
             }
@@ -146,6 +189,15 @@ open class HiddenSecretsPlugin : Plugin<Project> {
         }
 
         /**
+         * @return empty template file for [KOTLIN_FILE_NAME]
+         */
+        fun tmpKotlinFile(): File {
+            return project.file("$tmpFolder/kotlin/").listFiles()
+                ?.first { it.name == KOTLIN_FILE_NAME }
+                ?: throw IllegalStateException("Did not find temporary template for secrets!")
+        }
+
+        /**
          * If found, returns the Secrets.kt file in the Android app
          */
         fun getKotlinFile(): File? {
@@ -154,31 +206,39 @@ open class HiddenSecretsPlugin : Plugin<Project> {
 
         /**
          * Copy Cpp files from the lib to the Android project if they don't exist yet
+         * @param clean forces to overwrite files
          */
-        fun copyCppFiles() {
-            project.file("$tmpFolder/cpp/").listFiles()?.forEach {
-                val destination = getCppDestination(it.name)
-                if (destination.exists()) {
-                    println("${it.name} already exists")
+        fun copyCppFiles(clean: Boolean) {
+            project.file("$tmpFolder/cpp/").listFiles()?.forEach { tmpCppFile ->
+                val destination = getCppDestination(tmpCppFile.name)
+                if (!clean && destination.exists()) {
+                    println("${tmpCppFile.name} already exists")
                 } else {
-                    println("Copy $it.name to\n$destination")
-                    it.copyTo(destination, true)
+                    println("Copy ${tmpCppFile.name} to\n$destination")
+                    tmpCppFile.copyTo(destination, true)
                 }
             }
         }
 
         /**
          * Copy Kotlin file Secrets.kt from the lib to the Android project if it does not exist yet
+         * @param clean forces to overwrite files
          */
-        fun copyKotlinFile() {
-            getKotlinFile()?.let {
+        fun copyKotlinFile(clean: Boolean) {
+            val existingKotlinFile: File? = getKotlinFile()
+            if (existingKotlinFile != null && clean) {
+                println("Overwriting existing $KOTLIN_FILE_NAME.")
+                tmpKotlinFile().copyTo(existingKotlinFile, true)
+                return
+            }
+            if (existingKotlinFile != null) {
                 println("$KOTLIN_FILE_NAME already exists")
                 return
             }
             val packageName = getPackageNameParam()
             project.file("$tmpFolder/kotlin/").listFiles()?.forEach {
                 val destination = getKotlinDestination(packageName, it.name)
-                if (destination.exists()) {
+                if (destination.exists() && !clean) {
                     println("${it.name} already exists")
                 } else {
                     println("Copy $it.name to\n$destination")
@@ -188,10 +248,71 @@ open class HiddenSecretsPlugin : Plugin<Project> {
         }
 
         /**
+         * Main method of the project: add Cpp and Kotlin files to your project if necessary,
+         * obfuscate your secret key and add it to your project.
+         */
+        fun hideSecret(
+            keyName: String,
+            packageName: String,
+            obfuscatedKey: String
+        ) {
+            //Add method in Kotlin code
+            var secretsKotlin = getKotlinFile()
+            if (secretsKotlin == null) {
+                //File not found in project
+                secretsKotlin = getKotlinDestination(packageName, KOTLIN_FILE_NAME)
+            }
+            if (secretsKotlin.exists()) {
+                var text = secretsKotlin.readText(Charset.defaultCharset())
+                text = text.replace(PACKAGE_PLACEHOLDER, packageName)
+                if (text.contains(keyName)) {
+                    println("⚠️ Method already added in Kotlin !")
+                }
+                text = text.dropLast(1)
+                text += CodeGenerator.getKotlinCode(keyName)
+                secretsKotlin.writeText(text)
+            } else {
+                error("Missing Kotlin file, please run gradle task : $TASK_COPY_KOTLIN")
+            }
+            //Resolve package name for C++ from the one used in Kotlin file
+            var kotlinPackage = Utils.getKotlinFilePackage(secretsKotlin)
+            if (kotlinPackage.isEmpty()) {
+                println("Empty package in $KOTLIN_FILE_NAME")
+                kotlinPackage = packageName
+            }
+
+            //Add obfuscated key in C++ code
+            val secretsCpp = getCppDestination("secrets.cpp")
+            if (secretsCpp.exists()) {
+                var text = secretsCpp.readText(Charset.defaultCharset())
+                if (text.contains(obfuscatedKey)) {
+                    println("⚠️ Key already added in C++ !")
+                }
+                if (text.contains(KEY_PLACEHOLDER)) {
+                    //Edit placeholder key
+                    //Replace package name
+                    text = text.replace(PACKAGE_PLACEHOLDER, Utils.getSnakeCasePackageName(kotlinPackage))
+                    //Replace key name
+                    text = text.replace("YOUR_KEY_NAME_GOES_HERE", keyName)
+                    //Replace demo key
+                    text = text.replace(KEY_PLACEHOLDER, obfuscatedKey)
+                    secretsCpp.writeText(text)
+                } else {
+                    //Add new key
+                    text += CodeGenerator.getCppCode(kotlinPackage, keyName, obfuscatedKey)
+                    secretsCpp.writeText(text)
+                }
+            } else {
+                error("Missing C++ file, please run gradle task : $TASK_COPY_CPP")
+            }
+            println("✅ You can now get your secret key by calling : Secrets().get$keyName(packageName)")
+        }
+
+        /**
          * Unzip plugin into tmp directory
          */
         project.tasks.create(TASK_UNZIP_HIDDEN_SECRETS, Copy::class.java,
-            object : Action<Copy?> {
+            object : Action<Copy> {
                 @TaskAction
                 override fun execute(copy: Copy) {
                     // in the case of buildSrc dir
@@ -199,15 +320,20 @@ open class HiddenSecretsPlugin : Plugin<Project> {
                     println("Unzip jar to $tmpFolder")
                     copy.into(tmpFolder)
                 }
-            })
+            }).apply {
+            this.group = TASK_GROUP
+            this.description = "Unzip plugin into tmp directory"
+        }
 
         /**
          * Copy C++ files to your project
          */
         project.task(TASK_COPY_CPP)
         {
+            this.group = TASK_GROUP
+            this.description = "Copy C++ files to your project"
             doLast {
-                copyCppFiles()
+                copyCppFiles(clean = false)
             }
         }
 
@@ -216,8 +342,10 @@ open class HiddenSecretsPlugin : Plugin<Project> {
          */
         project.task(TASK_COPY_KOTLIN)
         {
+            this.group = TASK_GROUP
+            this.description = "Copy Kotlin file to your project"
             doLast {
-                copyKotlinFile()
+                copyKotlinFile(clean = false)
             }
         }
 
@@ -226,79 +354,68 @@ open class HiddenSecretsPlugin : Plugin<Project> {
          */
         project.task(TASK_OBFUSCATE)
         {
+            this.group = TASK_GROUP
+            this.description = "Get an obfuscated key from command line"
             doLast {
                 getObfuscatedKey()
             }
         }
 
         /**
-         * Obfuscate a key and add it to your Android project
+         * Clean all secret hidden keys in your project and obfuscate all keys from the properties file.
          */
         project.task(TASK_HIDE_SECRET)
         {
+            this.group = TASK_GROUP
+            this.description = "Obfuscate a key and add it to your Android project"
             dependsOn(TASK_UNZIP_HIDDEN_SECRETS)
 
             doLast {
                 //Assert that the key is present
                 getKeyParam()
                 //Copy files if they don't exist
-                copyCppFiles()
-                copyKotlinFile()
+                copyCppFiles(clean = false)
+                copyKotlinFile(clean = false)
 
                 val keyName = getKeyNameParam()
                 val packageName = getPackageNameParam()
                 val obfuscatedKey = getObfuscatedKey()
 
-                //Add method in Kotlin code
-                var secretsKotlin = getKotlinFile()
-                if (secretsKotlin == null) {
-                    //File not found in project
-                    secretsKotlin = getKotlinDestination(packageName, KOTLIN_FILE_NAME)
-                }
-                if (secretsKotlin.exists()) {
-                    var text = secretsKotlin.readText(Charset.defaultCharset())
-                    text = text.replace(PACKAGE_PLACEHOLDER, packageName)
-                    if (text.contains(keyName)) {
-                        println("⚠️ Method already added in Kotlin !")
-                    }
-                    text = text.dropLast(1)
-                    text += CodeGenerator.getKotlinCode(keyName)
-                    secretsKotlin.writeText(text)
-                } else {
-                    error("Missing Kotlin file, please run gradle task : $TASK_COPY_KOTLIN")
-                }
-                //Resolve package name for C++ from the one used in Kotlin file
-                var kotlinPackage = Utils.getKotlinFilePackage(secretsKotlin)
-                if (kotlinPackage.isEmpty()) {
-                    println("Empty package in $KOTLIN_FILE_NAME")
-                    kotlinPackage = packageName
-                }
+                hideSecret(
+                    keyName = keyName,
+                    packageName = packageName,
+                    obfuscatedKey = obfuscatedKey
+                )
+            }
+        }
 
-                //Add obfuscated key in C++ code
-                val secretsCpp = getCppDestination("secrets.cpp")
-                if (secretsCpp.exists()) {
-                    var text = secretsCpp.readText(Charset.defaultCharset())
-                    if (text.contains(obfuscatedKey)) {
-                        println("⚠️ Key already added in C++ !")
-                    }
-                    if (text.contains(KEY_PLACEHOLDER)) {
-                        //Edit placeholder key
-                        //Replace package name
-                        text = text.replace(PACKAGE_PLACEHOLDER, Utils.getSnakeCasePackageName(kotlinPackage))
-                        //Replace key name
-                        text = text.replace("YOUR_KEY_NAME_GOES_HERE", keyName)
-                        //Replace demo key
-                        text = text.replace(KEY_PLACEHOLDER, obfuscatedKey)
-                        secretsCpp.writeText(text)
-                    } else {
-                        //Add new key
-                        text += CodeGenerator.getCppCode(kotlinPackage, keyName, obfuscatedKey)
-                        secretsCpp.writeText(text)
-                    }
-                } else {
-                    error("Missing C++ file, please run gradle task : $TASK_COPY_CPP")
+        /**
+         * Obfuscate a keys from properties file and add it to your Android project
+         */
+        project.task(TASK_HIDE_SECRET_FROM_PROPS)
+        {
+            this.group = TASK_GROUP
+            this.description = "Re-generate and obfuscate keys from properties file and add it to your Android project"
+            dependsOn(TASK_UNZIP_HIDDEN_SECRETS)
+
+            doLast {
+                //Create a clean copy of dependency files
+                copyCppFiles(clean = true)
+                copyKotlinFile(clean = true)
+
+                val packageName = getPackageNameParam()
+                val propsFile = getPropertiesFile()
+                val props = getPropertiesFromFile(propertiesFile = propsFile)
+                println("Generating secrets from props: ${propsFile.path}")
+                props.entries.forEach { entry ->
+                    val keyName = entry.key as String
+                    val obfuscatedKey = Utils.encodeSecret(entry.value as String, packageName)
+                    hideSecret(
+                        keyName = keyName,
+                        packageName = packageName,
+                        obfuscatedKey = obfuscatedKey
+                    )
                 }
-                println("✅ You can now get your secret key by calling : Secrets().get$keyName(packageName)")
             }
         }
 
@@ -307,6 +424,8 @@ open class HiddenSecretsPlugin : Plugin<Project> {
          */
         project.task(TASK_PACKAGE_NAME)
         {
+            this.group = TASK_GROUP
+            this.description = "Print the package name of the app"
             doLast {
                 println("APP PACKAGE NAME = " + getPackageNameParam())
             }
@@ -316,6 +435,8 @@ open class HiddenSecretsPlugin : Plugin<Project> {
          * Find Secrets.kt file in the project
          */
         project.task(TASK_FIND_KOTLIN_FILE) {
+            this.group = TASK_GROUP
+            this.description = "Find Secrets.kt file in the project"
             doLast {
                 getKotlinFile()
             }

--- a/src/test/kotlin/CommandNamesTest.kt
+++ b/src/test/kotlin/CommandNamesTest.kt
@@ -10,6 +10,7 @@ class CommandNamesTest : StringSpec({
     HiddenSecretsPlugin.TASK_COPY_CPP shouldBe "copyCpp"
     HiddenSecretsPlugin.TASK_COPY_KOTLIN shouldBe "copyKotlin"
     HiddenSecretsPlugin.TASK_HIDE_SECRET shouldBe "hideSecret"
+    HiddenSecretsPlugin.TASK_HIDE_SECRET_FROM_PROPS shouldBe "hideSecretFromPropertiesFile"
     HiddenSecretsPlugin.TASK_OBFUSCATE shouldBe "obfuscate"
     HiddenSecretsPlugin.TASK_PACKAGE_NAME shouldBe "packageName"
     HiddenSecretsPlugin.TASK_FIND_KOTLIN_FILE shouldBe "findKotlinFile"


### PR DESCRIPTION
First of all amazing project! 👏

It almost works for our use case, so I&rsquo;ve decided to update the project a bit that it may fit others as well.


# Use case

Our use case is a bit different, we don&rsquo;t want to keep any secrets in the repository history. So in short:

-   Only CI would provide secrets and would build with it
-   For development we would have other secrets locally


# Solution

I&rsquo;ve updated and re-used same functionality to regenerate secrets from .properties files.

-   It picks up `.properties` file, finds key / value
-   Cleans cpp / kotlin files
-   Generates secrets from found key / value


# Other improvements

-   Updated docs
-   Added gradle info as well, now it will be visible when running `./gradlew tasks`
    
    ```
    Hide secrets tasks
    ------------------
    copyCpp - Copy C++ files to your project
    copyKotlin - Copy Kotlin file to your project
    findKotlinFile - Find Secrets.kt file in the project
    hideSecret - Obfuscate a key and add it to your Android project
    hideSecretFromProps - Re-generates and obfuscate keys from properties file and add it to your Android project
    obfuscate - Get an obfuscated key from command line
    packageName - Print the package name of the app
    unzipHiddenSecrets - Unzip plugin into tmp directory
    ```