### PR TITLE
Update underscore handling to match JNI spec

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,8 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
+insert_final_newline = true
 indent_size = 4
 indent_style = space
-insert_final_newline = false
 max_line_length = 120
 tab_width = 4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 
     testImplementation("io.kotest:kotest-runner-junit5-jvm:5.2.2")
     testImplementation("io.kotest:kotest-assertions-core-jvm:5.2.2")
+    testImplementation("io.kotest:kotest-framework-datatest-jvm:5.2.2")
     testImplementation("junit:junit:4.13.2")
 }
 

--- a/src/main/kotlin/com/klaxit/hiddensecrets/HiddenSecretsPlugin.kt
+++ b/src/main/kotlin/com/klaxit/hiddensecrets/HiddenSecretsPlugin.kt
@@ -288,6 +288,13 @@ open class HiddenSecretsPlugin : Plugin<Project> {
                 kotlinPackage = packageName
             }
 
+            /**
+             * There are certain rules for underscores in JNI spec, please see here:
+             * https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#resolving_native_method_names
+             */
+            val keyNameForJNI = keyName.replace("_", "_1")
+            println("keyNameForJNI: $keyNameForJNI")
+
             // Add obfuscated key in C++ code
             val secretsCpp = getCppDestination("secrets.cpp")
             if (secretsCpp.exists()) {
@@ -300,13 +307,13 @@ open class HiddenSecretsPlugin : Plugin<Project> {
                     // Replace package name
                     text = text.replace(PACKAGE_PLACEHOLDER, Utils.getCppPackageName(kotlinPackage))
                     // Replace key name
-                    text = text.replace("YOUR_KEY_NAME_GOES_HERE", keyName)
+                    text = text.replace("YOUR_KEY_NAME_GOES_HERE", keyNameForJNI)
                     // Replace demo key
                     text = text.replace(KEY_PLACEHOLDER, obfuscatedKey)
                     secretsCpp.writeText(text)
                 } else {
                     // Add new key
-                    text += CodeGenerator.getCppCode(kotlinPackage, keyName, obfuscatedKey)
+                    text += CodeGenerator.getCppCode(kotlinPackage, keyNameForJNI, obfuscatedKey)
                     secretsCpp.writeText(text)
                 }
             } else {

--- a/src/test/kotlin/IntegrationTest.kt
+++ b/src/test/kotlin/IntegrationTest.kt
@@ -1,0 +1,90 @@
+import com.klaxit.hiddensecrets.HiddenSecretsPlugin
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.data.Row4
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class IntegrationTest : WordSpec({
+
+    "Apply the plugin" should {
+        val testProjectDir = TemporaryFolder()
+        testProjectDir.create()
+        val buildFile = testProjectDir.newFile("build.gradle")
+        buildFile.appendText(
+            """
+        plugins {
+            id 'com.klaxit.hiddensecrets'
+            id 'com.android.application'
+        }
+        android {
+            compileSdkVersion 29
+        }
+        """.trimIndent()
+        )
+
+        val gradleRunner = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir.root)
+            .withTestKitDir(testProjectDir.newFolder())
+
+        withData(
+            Row4("thisIsATestKey", "thisIsATestKeyName", "thisIsATestKeyName", "com.package.test"),
+            Row4("this_is_a_test_key", "this_is_a_test_key_name", "this_1is_1a_1test_1key_1name", "com.package.test"),
+        ) { (key, keyName, keyNameCorrected, packageName) ->
+            "Make command ${HiddenSecretsPlugin.TASK_HIDE_SECRET} succeed" {
+                testProjectDir.run {
+                    val packagePath = packageName.replace('.', '/')
+                    val packageDirJava = newFolder("src/main/java/$packagePath")
+                    val packageDirCpp = newFolder("src/main/cpp/")
+
+                    val fileJava = File(packageDirJava, "Secrets.kt")
+                    val fileCpp = File(packageDirCpp, "secrets.cpp")
+
+                    var inputStream = javaClass.classLoader.getResourceAsStream("kotlin/Secrets.kt")
+                    inputStream?.bufferedReader()?.lines()?.forEach {
+                        fileJava.appendText(it + "\n")
+                    }
+                    inputStream?.close()
+
+                    inputStream = javaClass.classLoader.getResourceAsStream("cpp/secrets.cpp")
+                    inputStream?.bufferedReader()?.forEachLine {
+                        fileCpp.appendText(it + "\n")
+                    }
+                    inputStream?.close()
+
+                    gradleRunner.withArguments()
+                    val result = gradleRunner
+                        .withArguments(
+                            HiddenSecretsPlugin.TASK_HIDE_SECRET,
+                            "-Pkey=$key",
+                            "-PkeyName=$keyName",
+                            "-Ppackage=$packageName"
+                        )
+                        .build()
+                    println(result.output)
+
+                    var correctFunNameNotFound = true
+                    val expectedFunctionName = "Java_${packageName.replace('.', '_')}_Secrets_get$keyNameCorrected("
+                    println("expectedFunctionName: $expectedFunctionName")
+
+                    fileCpp.bufferedReader().forEachLine {
+                        if (correctFunNameNotFound && it.contains(keyNameCorrected)) {
+                            if (it.contains(expectedFunctionName)) {
+                                correctFunNameNotFound = false
+                            }
+                        }
+                    }
+                    correctFunNameNotFound shouldBe false
+
+                    fileJava.delete()
+                    fileCpp.delete()
+                    packageDirJava.delete()
+                    packageDirCpp.delete()
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Hey folks, nice plugin!

I declared my secrets in `SUPER_SECRET_SECRET` form, and Android Studio was suggesting to create `getSUPER_1SECRET_1SECRET` `external` methods in `Secrets.kt`. I then found an [answer](https://stackoverflow.com/a/35015592/13442292) why this was happening.

There is no test for the contents of the generated files as of now it seems, and it was not easy to create one :smiley: 

I threw together my limited understanding of `kotest` and bad knowledge of file operations in `Gradle` to at least check if function names match what JNI / AS would expect.

Detekt also did not like the absence of newlines, so I had to fix `.editorconfig`. If I did it the wrong way, please let me know!

~~Update: I edited the wrong file, the underscores should be converted in the `.cpp`, will fix that first then.~~
Update: Fixed.