### PR TITLE
Explicit visibility in generated Secrets.kt file

### DIFF
--- a/src/main/kotlin/com/klaxit/hiddensecrets/CodeGenerator.kt
+++ b/src/main/kotlin/com/klaxit/hiddensecrets/CodeGenerator.kt
@@ -25,7 +25,7 @@ object CodeGenerator {
      * Kotlin code that will be added in your project
      */
     fun getKotlinCode(keyName: String): String {
-        return "\n    external fun get$keyName(packageName: String): String\n" +
+        return "\n    public external fun get$keyName(packageName: String): String\n" +
                 "}"
     }
 }

--- a/src/main/resources/kotlin/Secrets.kt
+++ b/src/main/resources/kotlin/Secrets.kt
@@ -1,11 +1,11 @@
 package YOUR_PACKAGE_GOES_HERE
 
-class Secrets {
+public class Secrets {
 
     // Method calls will be added by gradle task hideSecret
     // Example : external fun getWellHiddenSecret(packageName: String): String
 
-    companion object {
+    internal companion object {
         init {
             System.loadLibrary("secrets")
         }


### PR DESCRIPTION
When Kotlin Explicit API is enabled (https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors), any builds involving the generated Secrets file will fail, as it does not contain any visibility information. Editing the generated file is not an option, as future regenerations (such as, for example, CI runs) will erase the visibility modifier.  

In the case of the project I am working on, explicitApi() is on, even in `com.android.application` modules, mostly for consistency with the rest of the modules. That of course leads to many complaints from the compiler from the generated source. Another option would be the make a module just for Secrets.kt and disable explicitApi() there, but that is a lot of unneeded work, especially when most code generation libraries (Room, SQLDelight, etc.) have taken to generating visibility modifiers. 

Kotlin's default visibility is `public` (https://kotlinlang.org/docs/visibility-modifiers.html), so such changes will not cause any behavior change to any current users of the plugin. The companion object has been kept internal, as I can't really see a reason to want to access it. (Companion extension methods ?).